### PR TITLE
Add pathDisplayOption

### DIFF
--- a/doc/ddu-column-icon_filename.txt
+++ b/doc/ddu-column-icon_filename.txt
@@ -55,6 +55,15 @@ iconWidth	(number)
 
 		Default: 1
 
+				*ddu-column-icon_filename-param-pathDisplayOption*
+pathDisplayOption	(string)
+		Display options for file name.
+
+		"basename"	Displays only filename.
+		"relative"	Displays paths relative to the current directory.
+
+		Default: "basename"
+
 				*ddu-column-icon_filename-param-defaultIcon*
 defaultIcon	(dictionary)
 		It specifies default icon which is used when none of the


### PR DESCRIPTION
# EN
Added `pathDisplayOption` to `params`.

By default, only the file name is displayed(`basename`), but I wanted to know which directory the file belonged to, so I added the `relative` option.

# JA
`params`に`pathDisplayOption`を追加しました。
デフォルトではファイル名のみが表示されていますが，ファイル名がどのディレクトリに属しているかも知りたかったので`relative`オプションを追加しました。

---

# Sample 
## `basename`

<img width="876" alt="basename" src="https://user-images.githubusercontent.com/17854286/216033612-dcf43c86-91fa-4a89-8ab4-24dceab2c15e.png">

## `relative`

<img width="876" alt="relative" src="https://user-images.githubusercontent.com/17854286/216033767-fc370040-940d-4533-891d-eb700dd3d30c.png">
